### PR TITLE
Added autoload to the Composer package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,5 +14,8 @@
     ],
     "require": {
         "php": ">=5.3.0"
+    },
+    "autoload": {
+        "psr-0": { "Chill": "" }
     }
 }


### PR DESCRIPTION
When installing the library with Composer, no autoload is configured for this package.

This PR adds Chill to the composer autoloader.
