### PR TITLE
Corrected parameter type hint in Document

### DIFF
--- a/Chill/Document.php
+++ b/Chill/Document.php
@@ -58,7 +58,7 @@ class Document
 	* @param Chill $chill Chill class.
 	* @param array $doc (Optional) Document data.
 	*/
-	public function __construct(Chill $chill, array $doc = array())
+	public function __construct(Client $chill, array $doc = array())
 	{		
 		$this->chill	= $chill;
 		$this->data		= $doc;


### PR DESCRIPTION
Changed \Chill\Chill to \Chill\Client. Fix issue #1.
