### PR TITLE
Corrected undefined variable $response

### DIFF
--- a/Chill/Client.php
+++ b/Chill/Client.php
@@ -133,9 +133,9 @@ class Client
 	*/
 	protected function getViewByGet($url)
 	{
-		$rtn = $this->getCache($url);
+		$response = $this->getCache($url);
 		
-		if(!$rtn)
+		if(!$response)
 		{
 			list($status, $response) = $this->sendRequest($url);
 									


### PR DESCRIPTION
In method \Chill\Client::getViewByGet, undefined variable $response.
Corrected it by renaming $rtn to $response.
