### PR TITLE
Support for arrays passed as parameter values.

### DIFF
--- a/Chill/Client.php
+++ b/Chill/Client.php
@@ -102,7 +102,7 @@ class Client
 			$v = is_string($v) ? '"'.$v.'"' : $v;
 			$v = is_bool($v) ? $v ? 'true' : 'false' : $v;
 			$v = is_array($v) ? json_encode($v) : $v;
-			$query[] = $k . '=' . $v;
+			$query[] = $k . '=' . urlencode($v);
 		}
 		
 		$url = '_design/'.$design.'/_view/'.$view.'?'.implode('&', $query);


### PR DESCRIPTION
A simple one-liner. This is useful for supplying a startkey or endkey that is an array, i.e. startkey=[theatre,1360971932]
