### PR TITLE
Added setCacheEnabled(boolean) method to allow disabling/enabling of cac...

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+composer.lock
+vendor

--- a/Chill/Client.php
+++ b/Chill/Client.php
@@ -89,7 +89,23 @@ class Client
 	{
 		$this->url = $scheme . '://' . $host . ':' . $port . '/' . $db . '/';
 	}
-	
+
+	/**
+	 * Enables or disables the cache;
+	 *
+	 * @param $bool True to enable cache, false to disable it. Caching is enabled by default.
+	 * @return bool The setting for the cache after calling
+	 */
+	public function setCacheEnabled($bool)
+	{
+		if ($bool && !is_array($this->cache)) {
+			$this->cache = array();
+		} else {
+			$this->cache = null;
+		}
+		return isset($this->cache);
+	}
+
 	/**
 	* Get the results of a CouchDb view as an array of arrays, or Chill Document objects.
 	* 
@@ -139,9 +155,7 @@ class Client
 	*/
 	protected function getViewByGet($url)
 	{
-		$response = $this->getCache($url);
-		
-		if(!$response)
+		if(! isset($this->cache) || ! $response = $this->getCache($url))
 		{
 			list($status, $response) = $this->sendRequest($url);
 									
@@ -203,9 +217,7 @@ class Client
 	*/
 	public function get($id, $cache = true)
 	{
-		$rtn = $this->getCache($id);
-		
-		if(!$cache || !$rtn)
+		if(! isset($this->cache) || ! $rtn = $this->getCache($id))
 		{
 			list($status, $doc) = $this->sendRequest(urlencode($id));
 						
@@ -317,7 +329,7 @@ class Client
 	}
 	
 	/**
-	* Get a document from this class' internal cache.
+	* Get a document from this class' internal cache. Behaviour is unchanged if the cache is not in use.
 	* 
 	* @param string	$id	ID to get from cache.
 	*/
@@ -339,9 +351,15 @@ class Client
 	*/
 	protected function setCache($id, $value)
 	{
-		$this->cache[$id] = $value;
-		
-		return $this->cache[$id];
+		if (isset($this->cache))
+		{
+			$this->cache[$id] = $value;
+			return $this->cache[$id];
+		}
+		else
+		{
+			return $value;
+		}
 	}
 	
 	/**

--- a/Chill/Client.php
+++ b/Chill/Client.php
@@ -215,11 +215,12 @@ class Client
 	* @param bool	$cache	Whether or not to use the cache.
 	* @link http://wiki.apache.org/couchdb/HTTP_Document_API#GET
 	*/
-	public function get($id, $cache = true)
+	public function get($id, $cache = true, $encodeId = true)
 	{
 		if(! isset($this->cache) || ! $rtn = $this->getCache($id))
 		{
-			list($status, $doc) = $this->sendRequest(urlencode($id));
+			$docId = ($encodeId ? urlencode($id) : $id);
+			list($status, $doc) = $this->sendRequest($docId);
 						
 			if($status == 200)
 			{
@@ -241,15 +242,16 @@ class Client
 	* @param array	$doc	Document to store.
 	* @link http://wiki.apache.org/couchdb/HTTP_Document_API#PUT
 	*/
-	public function put($id, array $doc)
+	public function put($id, array $doc, $encodeId = true)
 	{
 		$context = array('http' => array());
 		
 		$context['http']['method']	= 'PUT';
 		$context['http']['header']	= 'Content-Type: application/json';
 		$context['http']['content']	= json_encode($doc);
-		
-		list($status, $response) = $this->sendRequest(urlencode($id) . (isset($doc['_rev']) ? '?rev=' . $doc['_rev'] : ''), $context);
+
+		$docId = ($encodeId ? urlencode($id) : $id);
+		list($status, $response) = $this->sendRequest($docId . (isset($doc['_rev']) ? '?rev=' . $doc['_rev'] : ''), $context);
 		
 		if($status == 409)
 		{

--- a/Chill/Client.php
+++ b/Chill/Client.php
@@ -191,7 +191,7 @@ class Client
 				
 		if($status != 200)
 		{
-			throw new \Chill\Exception\Response('POST View - Unknown response status.');
+			throw new \Chill\Exception\Response(sprintf('POST View - Unrecognised response status: %s',$status));
 		}
 		
 		return $this->asDocs ? $this->toDocuments($response) : $response;
@@ -255,11 +255,11 @@ class Client
 		
 		if($status == 409)
 		{
-			throw new \Chill\Exception\Conflict('PUT /' . $id . ' failed.');
+			throw new \Chill\Exception\Conflict(sprintf('PUT /%s failed: %s',$docId,isset($response['reason']) ? $response['reason'] : 'n/a'));
 		}
 		elseif($status != 201)
 		{
-			throw new \Chill\Exception\Response('PUT /' . $id . ' - Unknown response status.');
+			throw new \Chill\Exception\Response(sprintf('PUT /%s - Unrecognised response status: %s',$docId,$status));
 		}
 				
 		if(isset($response['id']))
@@ -290,7 +290,7 @@ class Client
 		
 		if($status != 201)
 		{
-			throw new \Chill\Exception\Response('POST - Unknown response status.');
+			throw new \Chill\Exception\Response(sprintf('POST - Unrecognised response status: %s',$status));
 		}
 				
 		if(isset($response['id']))
@@ -319,7 +319,7 @@ class Client
 				
 		if($status != 200)
 		{
-			throw new \Chill\Exception\Response('DELETE - Unknown response status.');
+			throw new \Chill\Exception\Response(sprintf('DELETE /%s - Unrecognised response status: %s',$id,$status));
 		}
 		
 		if($this->getCache($id))

--- a/composer.json
+++ b/composer.json
@@ -1,9 +1,9 @@
 {
     "name": "chill/chill",
     "type": "library",
-    "description": "CouchDb client library for PHP 5.3+",
+    "description": "CouchDb/Cloudant client library for PHP 5.3+; a fork from Dan Cryer's original version",
     "keywords": ["couchdb", "couch", "database", "client", "library"],
-    "homepage": "https://github.com/dancryer/Chill",
+    "homepage": "https://github.com/sjchristian/Chill",
     "license": "BSD-2-Clause",
     "authors": [
         {
@@ -11,15 +11,21 @@
             "email": "dan@dancryer.com",
             "homepage": "http://www.dancryer.com",
             "role": "Developer"
+        },
+        {
+            "name": "Simon Christian",
+            "email": "sjchristian@gmail.com",
+            "role": "Developer"
         }
     ],
     "require": {
-        "php": ">=5.3.0"
+        "php": ">=5.3.0",
+        "psr/log": "1.0.*"
     },
     "autoload": {
         "psr-0": { "Chill": "" }
     },
     "support": {
-        "issues": "https://github.com/dancryer/Chill/issues"
+        "issues": "https://github.com/sjchristian/Chill/issues"
     }
 }


### PR DESCRIPTION
This change allows the default caching behaviour to be disabled:
- avoids caching _every_ response to a get/getViewByGet call, which is likely to cause memory issues on a long-running process
- saves having to disable caching on every call to get(), which causes somewhat unexpected behaviour for the unwary
